### PR TITLE
Adding OSX Library path to build settings

### DIFF
--- a/filesystems-objc/YTFS/YTFS.xcodeproj/project.pbxproj
+++ b/filesystems-objc/YTFS/YTFS.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				COPY_PHASE_STRIP = NO;
+				FRAMEWORK_SEARCH_PATHS = "/Library/Frameworks/**";
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -256,6 +257,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				FRAMEWORK_SEARCH_PATHS = "/Library/Frameworks/**";
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = YTFS_Prefix.pch;


### PR DESCRIPTION
When I cloned the repo I couldn't build the YouTube filesystem. Had to add the library path for it to build. 
