### PR TITLE
Adding O_TRUNC in the list of flags while creating new files. This is…

### DIFF
--- a/filesystems-objc/LoopbackFS/LoopbackFS.m
+++ b/filesystems-objc/LoopbackFS/LoopbackFS.m
@@ -109,7 +109,7 @@
                    error:(NSError **)error {
   NSString* p = [rootPath_ stringByAppendingString:path];
   mode_t mode = [[attributes objectForKey:NSFilePosixPermissions] longValue];
-  int fd = open([p UTF8String], O_CREAT | O_RDWR, mode);
+  int fd = open([p UTF8String], O_CREAT | O_TRUNC | O_RDWR, mode);
   if ( fd < 0 ) {
     if ( error ) {
       *error = [NSError errorWithPOSIXCode:errno];


### PR DESCRIPTION
… according to https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/creat.2.html