### PR TITLE
Fix minixfs count_free causing segmentfault bug

### DIFF
--- a/filesystems-c/unixfs/common/linux/linux.c
+++ b/filesystems-c/unixfs/common/linux/linux.c
@@ -32,7 +32,7 @@ sb_getblk(struct super_block* sb, sector_t block)
         abort();
     }
     bh->b_flags.dynamic = 1;
-    bh->b_size = PAGE_SIZE;
+    bh->b_size = sb->s_blocksize;
     bh->b_blocknr = block;
     return bh;
 }


### PR DESCRIPTION
In count_free function, bh->b_size = 4096, cause ((numbits - (numblocks - 1) * bh->b_size * 8) / 16) * 2 => 2305843009213672946, so bh->b_data[j] visit novalid memory.
Use linux 4.10.15 minix count_free_* code to replace the count_free_* functions. The new code is efficient and strong.