### PR TITLE
Fix building unixfs/ufs on ARM

### DIFF
--- a/filesystems-c/unixfs/common/unixfs/unixfs_internal.c
+++ b/filesystems-c/unixfs/common/unixfs/unixfs_internal.c
@@ -83,14 +83,12 @@ unixfs_inodelayer_fini(void)
                     "*** warning: ihash terminated when not empty (%lu)\n",
                     (unsigned long)ihash_count);
 
-            int node_index = 0;
             u_long ihash_index = 0;
             for (; ihash_index < ihash_mask; ihash_index++) {
                 struct inode* ip;
                 LIST_FOREACH(ip, &ihash_table[ihash_index], I_hashlink) {
                     fprintf(stderr, "*** warning: inode %llu still present\n",
                             (ino64_t)ip->I_number);
-                    node_index++;
                 }
             }
         }
@@ -267,7 +265,6 @@ unixfs_inodelayer_dump(unixfs_inodelayer_iterator_t it)
 {
     pthread_mutex_lock(&ihash_lock);
 
-    int node_index = 0;
     u_long ihash_index = 0;
 
     for (; ihash_index < ihash_mask; ihash_index++) {
@@ -275,7 +272,6 @@ unixfs_inodelayer_dump(unixfs_inodelayer_iterator_t it)
         LIST_FOREACH(ip, &ihash_table[ihash_index], I_hashlink) {
             if (it(ip, ip->I_private) != 0)
                 goto out;
-            node_index++;
         }
     }
 

--- a/filesystems-c/unixfs/ufs/Makefile
+++ b/filesystems-c/unixfs/ufs/Makefile
@@ -29,7 +29,7 @@ CFLAGS_OSXFUSE += -I$(UNIXFS)
 
 CFLAGS_EXTRA = -Wall -Werror -g $(CFLAGS)
 
-LIBS = -losxfuse
+LIBS = -losxfuse.2
 
 all: $(TARGETS)
 

--- a/filesystems-c/unixfs/ufs/ufs.c
+++ b/filesystems-c/unixfs/ufs/ufs.c
@@ -355,11 +355,8 @@ ufs_read_cylinder_structures(struct super_block* sb)
     unsigned char* base;
     unsigned char* space;
     unsigned size, blks, i;
-    struct ufs_super_block_third* usb3;
 
     UFSD("ENTER\n");
-
-    usb3 = ubh_get_usb_third(uspi);
 
     /* Read cs structures from (usually) first data block on the device. */
 
@@ -1474,15 +1471,13 @@ U_ufs_statvfs(struct super_block* sb, struct statvfs* buf)
     unsigned flags = UFS_SB(sb)->s_flags;
 
     struct ufs_super_block_first*  usb1;
-    struct ufs_super_block_second* usb2;
     struct ufs_super_block_third*  usb3;
 
     lock_kernel();
 
     usb1 = ubh_get_usb_first(uspi);
-    usb2 = ubh_get_usb_second(uspi);
     usb3 = ubh_get_usb_third(uspi);
-    
+
     if ((flags & UFS_TYPE_MASK) == UFS_TYPE_UFS2) {
         /* buf->f_type = UFS2_MAGIC; */
         buf->f_blocks = fs64_to_cpu(sb, usb3->fs_un1.fs_u2.fs_dsize);


### PR DESCRIPTION
* The `do_div` macro was in x86 assembly
* Missing macro for bits per long
* Modern clang fails when local variables are unused

Tested with NeXTStep cd image on macOS 14.5